### PR TITLE
Wait for Ctrl-D to finish to prevent filesystem reformat upon following Ctrl-C

### DIFF
--- a/src/rp2/pyboard.ts
+++ b/src/rp2/pyboard.ts
@@ -160,12 +160,12 @@ export default class Pyboard {
     await this.send(CTRL_B);
   }
 
-  private async softReset(timeout: number): Promise<unknown> {
+  public async softReset(timeout: number): Promise<unknown> {
     if (!timeout) {
       timeout = 5000;
     }
     this.logger.info('Soft reset');
-    let waitFor = this.status === RAW_REPL ? '>' : 'OK';
+    let waitFor = this.status === RAW_REPL ? '>' : '>>>';
     return await this.sendWait(CTRL_D, waitFor, timeout);
   }
 

--- a/src/rp2/runner.ts
+++ b/src/rp2/runner.ts
@@ -39,7 +39,7 @@ export default class Runner {
       return;
     }
 
-    await this.board.softResetNoFollow();
+    await this.board.softReset(5000);
 
     this.terminal.writeln('Running ' + currentFile.filename);
     this.busy = true;


### PR DESCRIPTION
This PR contains a small change to ensure that when rebooting a Pico board with Ctrl-D before running a Python file, the extension waits until the board has rebooted before issuing a subsequent Ctrl-C. This prevents the filesystem on the Pico board being erased in response to its boot process being interrupted, as per [this issue](https://github.com/micropython/micropython/issues/10898) and [this PR](https://github.com/micropython/micropython/pull/10833) (both in the MicroPython project).

This addresses [this issue](https://github.com/paulober/Pico-W-Go/issues/46) in the Pico-W-Go extension.

Currently, this change has been tested on Ubuntu 22.04 and VS code 1.75.1.