### PR TITLE
Increased timeout on pyserial detection

### DIFF
--- a/src/osHelper.mts
+++ b/src/osHelper.mts
@@ -24,7 +24,7 @@ export async function getPythonCommand(): Promise<string | undefined> {
   return new Promise(resolve => {
     exec(
       `${pythonCommand} --version`,
-      { timeout: 1000 },
+      { timeout: 2500 },
       (error, stdout, stderr) => {
         if (error) {
           console.error(`Error executing ${pythonCommand}: ${error.message}`);

--- a/src/osHelper.mts
+++ b/src/osHelper.mts
@@ -76,7 +76,7 @@ export async function writeJsonFile(path: string, content: any): Promise<void> {
 export function isPyserialInstalled(pyCommand: string): boolean {
   try {
     const output = execSync(`${pyCommand} -m pip show pyserial`, {
-      timeout: 1000,
+      timeout: 5000,
     });
     return output.toString("utf-8").includes("Name: pyserial");
   } catch (error) {


### PR DESCRIPTION
(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.

Extension initialization always failed on pyserial detection, turns out the command timeout is too low for my machine.

![image](https://user-images.githubusercontent.com/15722040/232602183-72d46904-9dec-43d9-a864-7f84036ce15f.png)


## Does this close any currently open issues?

No

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*


## Any other comments?


## Where has this been tested?

**Operating system:** Windows 11

**VSCode version:** 1.77.1

**Pico-W-Go version:** 3.0.3
