### PR TITLE
Patch v3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to the "pico-w-go" extension will be documented in this file
 
 ---
 
+## [3.0.10] - 2023-06-03
+
+# Changed
+- The minimum VSCode engine version was lowered to v1.76.0 for better compaibility with Raspberry Pi
+
 ## [3.0.9] - 2023-06-02
 
 # Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pico-w-go",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pico-w-go",
-      "version": "3.0.9",
+      "version": "3.0.10",
       "cpu": [
         "x64",
         "arm64",
@@ -34,7 +34,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.x",
         "@types/uuid": "^9.0.1",
-        "@types/vscode": "^1.77.0",
+        "@types/vscode": "^1.76.0",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
         "@vscode/test-electron": "^2.3.2",
@@ -48,7 +48,7 @@
       },
       "engines": {
         "node": ">=16.14.2",
-        "vscode": "^1.77.0"
+        "vscode": "^1.76.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pico-w-go",
   "displayName": "Pico-W-Go",
   "description": "Autocompletion, remote Workspace and a REPL console for the Raspberry Pi Pico (W).",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "publisher": "paulober",
   "license": "MPL-2.0",
   "homepage": "https://github.com/paulober/Pico-W-Go/blob/main/README.md",
@@ -20,7 +20,7 @@
   },
   "markdown": "github",
   "engines": {
-    "vscode": "^1.77.0",
+    "vscode": "^1.76.0",
     "node": ">=16.14.2"
   },
   "keywords": [
@@ -419,7 +419,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.x",
     "@types/uuid": "^9.0.1",
-    "@types/vscode": "^1.77.0",
+    "@types/vscode": "^1.76.0",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "@vscode/test-electron": "^2.3.2",


### PR DESCRIPTION
### Changed
- The minimum VSCode engine version was lowered to `v1.76.0` for better compaibility with Raspberry Pi
